### PR TITLE
feat(make-fetching): allow mapping a method to multiple flags

### DIFF
--- a/__tests__/make-fetching.ts
+++ b/__tests__/make-fetching.ts
@@ -130,4 +130,140 @@ describe('makeFetching', () => {
 
     expect(instance.isLoading).to.equal(false);
   });
+
+  it('should toggle multiple flags from a single method when given an array', () => {
+    const observed: { isLoading: boolean; isBusy: boolean }[] = [];
+    const instance = {
+      isLoading: false,
+      isBusy: false,
+      run() {
+        observed.push({ isLoading: instance.isLoading, isBusy: instance.isBusy });
+
+        return 'done';
+      },
+    };
+
+    makeFetching(instance, { run: ['isLoading', 'isBusy'] });
+
+    const result = instance.run();
+
+    expect(result).to.equal('done');
+    expect(observed).to.deep.equal([{ isLoading: true, isBusy: true }]);
+    expect(instance.isLoading).to.equal(false);
+    expect(instance.isBusy).to.equal(false);
+  });
+
+  it('should flip all flags true on call and false on settle for async multi-flag methods', async () => {
+    let resolvePromise: ((value: string) => void) | undefined;
+    const instance = {
+      isLoading: false,
+      isRefreshing: false,
+      run() {
+        return new Promise<string>((resolve) => {
+          resolvePromise = resolve;
+        });
+      },
+    };
+
+    makeFetching(instance, { run: ['isLoading', 'isRefreshing'] });
+
+    const promise = instance.run();
+
+    expect(instance.isLoading).to.equal(true);
+    expect(instance.isRefreshing).to.equal(true);
+
+    resolvePromise?.('done');
+    await promise;
+
+    expect(instance.isLoading).to.equal(false);
+    expect(instance.isRefreshing).to.equal(false);
+  });
+
+  it('should ignore an empty flag array without wrapping the method', () => {
+    let callCount = 0;
+    const instance = {
+      isLoading: false,
+      run() {
+        callCount += 1;
+
+        return 'done';
+      },
+    };
+    const originalRun = instance.run;
+
+    makeFetching(instance, { run: [] });
+
+    expect(instance.run).to.equal(originalRun);
+
+    const result = instance.run();
+
+    expect(result).to.equal('done');
+    expect(callCount).to.equal(1);
+    expect(instance.isLoading).to.equal(false);
+  });
+
+  it('should block repeated calls only when every lock flag is already set in multi-flag mode', async () => {
+    const resolvers: ((value: string) => void)[] = [];
+    let callCount = 0;
+    const instance = {
+      isLoading: false,
+      isBusy: false,
+      run() {
+        callCount += 1;
+
+        return new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        });
+      },
+    };
+
+    makeFetching(instance, { run: ['isLoading', 'isBusy'] }, true);
+
+    const firstPromise = instance.run();
+
+    expect(callCount).to.equal(1);
+    expect(instance.isLoading).to.equal(true);
+    expect(instance.isBusy).to.equal(true);
+
+    // Every lock flag is set — the second call must be dropped.
+    const secondResult = instance.run();
+
+    expect(secondResult).to.be.undefined;
+    expect(callCount).to.equal(1);
+
+    resolvers[0]?.('done');
+    await firstPromise;
+
+    expect(instance.isLoading).to.equal(false);
+    expect(instance.isBusy).to.equal(false);
+
+    // After settle, both flags are false — new call goes through.
+    const thirdPromise = instance.run();
+
+    expect(callCount).to.equal(2);
+
+    resolvers[1]?.('done-again');
+    await thirdPromise;
+  });
+
+  it('should not block when only some lock flags are already set in multi-flag mode', () => {
+    const observed: { isLoading: boolean; isBusy: boolean }[] = [];
+    let callCount = 0;
+    const instance = {
+      isLoading: false,
+      isBusy: true,
+      run() {
+        callCount += 1;
+        observed.push({ isLoading: instance.isLoading, isBusy: instance.isBusy });
+      },
+    };
+
+    makeFetching(instance, { run: ['isLoading', 'isBusy'] }, true);
+
+    // `isBusy` is true but `isLoading` is not — `.every()` is false, call proceeds.
+    instance.run();
+
+    expect(callCount).to.equal(1);
+    expect(observed).to.deep.equal([{ isLoading: true, isBusy: true }]);
+  });
 });

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -401,7 +401,8 @@ The root export is the safest contract. Subpath imports are available in the pub
 - Purpose: wrap methods so they toggle boolean loading flags around sync or async execution
 - Notes:
   - supports multiple concurrent async calls
-  - with `hasLock = true`, it drops calls while the flag is already `true`
+  - each method may map to a single flag (`'isLoading'`) or to a `readonly` tuple of flags (`['isLoading', 'isRefreshing'] as const`); tuple flags flip together inside one `runInAction`
+  - with `hasLock = true`, it drops calls while **every** mapped flag is already `true`
 
 `makeExported`
 

--- a/docs/api/helpers.md
+++ b/docs/api/helpers.md
@@ -39,6 +39,19 @@ makeFetching(this, {
 });
 ```
 
+Each method maps to one flag — or to several flags via a `readonly` tuple. All
+flags in the tuple flip in a single `runInAction`, so observers see them change
+atomically:
+
+```ts
+makeFetching(this, {
+  verify: ['isVerifying', 'hasStartedBrowserFromModal'] as const,
+});
+```
+
+When `hasLock` is `true`, the method call is dropped only while **every** mapped
+flag is already `true`, so a partially-set state still lets the call through.
+
 ## `makeExported(store, params)`
 
 Controls what parts of the store become exportable or serializable.

--- a/src/make-fetching.ts
+++ b/src/make-fetching.ts
@@ -10,8 +10,10 @@ type BooleanKeys<T> = {
   [K in keyof T]-?: T[K] extends boolean ? K : never;
 }[keyof T];
 
-type StrictParams<T> = Partial<Record<MethodKeys<T>, BooleanKeys<T>>>;
-type UnsafeParams = Record<string, string>;
+type AtLeastTwo<T> = readonly [T, T, ...T[]];
+type StrictParamValue<T> = BooleanKeys<T> | AtLeastTwo<BooleanKeys<T>>;
+type StrictParams<T> = Partial<Record<MethodKeys<T>, StrictParamValue<T>>>;
+type UnsafeParams = Record<string, string | readonly string[]>;
 
 function makeFetching<T extends Record<any, any>>(
   instance: T,
@@ -29,13 +31,23 @@ function makeFetching<T extends Record<any, any>>(
   params: StrictParams<T> | UnsafeParams = {},
   hasLock = false,
 ): void {
-  Object.entries(params).forEach(([funcName, propName]) => {
+  Object.entries(params).forEach(([funcName, propNameOrNames]) => {
+    const propNames = (Array.isArray(propNameOrNames) ? propNameOrNames : [propNameOrNames]).filter(
+      Boolean,
+    ) as string[];
+
+    if (propNames.length === 0) {
+      return;
+    }
+
     const callback = instance[funcName] as (...arg: any[]) => any;
     let inFlight = 0;
     const setValue = (value: boolean): void => {
       runInAction(() => {
-        // @ts-expect-error not necessary
-        instance[propName] = value;
+        for (const propName of propNames) {
+          // @ts-expect-error not necessary
+          instance[propName] = value;
+        }
       });
     };
     const increment = (): void => {
@@ -55,7 +67,7 @@ function makeFetching<T extends Record<any, any>>(
 
     // @ts-expect-error not necessary
     instance[funcName] = (...args: any[]) => {
-      if (hasLock && instance[propName]) {
+      if (hasLock && propNames.every((name) => instance[name])) {
         return;
       }
 


### PR DESCRIPTION
## Motivation

Currently `makeFetching` maps one method → one boolean flag. That works for the
common case, but a method that legitimately toggles more than one loading flag
at the same time has no clean path:

- Calling `makeFetching` twice for the same method double-wraps the instance
  method and corrupts the internal `inFlight` counter (the second wrapper sees
  the already-wrapped function as its callback).
- Falling back to manual `runInAction` for the extra flag defeats the helper's
  whole purpose — the whole point of `makeFetching` is that callers never
  reach for `runInAction` by hand.

We hit this in a downstream consumer when a `verify()` method needed to flip
both `isVerifying` (general "request in flight") and `hasStartedBrowserFromModal`
(a one-shot UX guard) in the same runInAction.

## Change

Widen the mapping so a method can point at a single flag _or_ at a `readonly`
tuple of flags:

```ts
type AtLeastTwo<T> = readonly [T, T, ...T[]];
type StrictParamValue<T> = BooleanKeys<T> | AtLeastTwo<BooleanKeys<T>>;
type StrictParams<T> = Partial<Record<MethodKeys<T>, StrictParamValue<T>>>;
type UnsafeParams = Record<string, string | readonly string[]>;
```

Usage:

```ts
makeFetching(this, {
  verify: ['isVerifying', 'hasStartedBrowserFromModal'] as const,
});
```

All flags in the tuple flip inside **one** `runInAction`, so observers never
see an intermediate "half-set" state.

### Behaviour details

- The single-string form is fully backward compatible — no existing call site
  needs to change; the new `StrictParamValue<T>` is a superset of `BooleanKeys<T>`.
- An empty flag array (`run: []`) is a defensive no-op: the helper skips the
  wrap and leaves the original method in place. This matters when the flag
  list is computed dynamically.
- `hasLock` drops a call only when **every** mapped flag is already `true`.
  A partially-set state still lets the call through, which preserves the
  "no duplicate in-flight" invariant the single-flag lock was providing.

## Tests

Added 5 new cases in `__tests__/make-fetching.ts`:

1. Multi-flag sync: both flags are observed `true` inside the method body and
   back to `false` after it returns.
2. Multi-flag async: both flags stay `true` until the promise settles, then
   both are `false`.
3. Empty-array no-op: the method is not wrapped, call count and flag state
   are unaffected.
4. `hasLock` with every flag set: second concurrent call is dropped; a third
   call after settle goes through.
5. `hasLock` with only some flags set: `.every()` is `false`, the call still
   proceeds.

All existing cases continue to pass unchanged.

```
$ npm test
Test Files  25 passed (25)
     Tests  90 passed (90)
```

Lint (`npm run lint:check`), typecheck (`npm run ts:check`), and build
(`npm run build`) are all clean.

## Compatibility

- **Public API:** the overload list for `makeFetching` is unchanged; only the
  value type of `StrictParams<T>` / `UnsafeParams` is widened, which is a
  non-breaking extension.
- **Runtime:** the single-string code path goes through the same `Array.isArray`
  normalization as before (wrapped into a one-element array). For single-flag
  consumers the observable behaviour is identical.
