### PR TITLE
fix(make-fetching): preserve this binding and harden against sync errors

### DIFF
--- a/src/make-fetching.ts
+++ b/src/make-fetching.ts
@@ -73,11 +73,21 @@ function makeFetching<T extends Record<any, any>>(
 
       increment();
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      const result = callback(...args);
+      let result: unknown;
 
-      if (typeof result === 'object' && result.finally) {
-        result.finally(() => {
+      try {
+        result = callback.apply(instance, args);
+      } catch (error) {
+        decrement();
+        throw error;
+      }
+
+      if (
+        result &&
+        typeof result === 'object' &&
+        typeof (result as { finally?: unknown }).finally === 'function'
+      ) {
+        void (result as Promise<unknown>).finally(() => {
           decrement();
         });
       } else {


### PR DESCRIPTION
Mirrors the equivalent fix applied in janitorai/monojai#831 (in-repo copy of the same helper).

## Problem

makeFetching was invoking callback(...args) without binding to instance, which broke class methods that reference this (e.g. async store actions). The wrapped method lost its context and crashed silently when it tried to access this.anything().

## Fix

1. Use callback.apply(instance, args) to preserve the this binding.
2. Wrap the call in try/catch so a sync error before the promise is returned still decrements inFlight instead of leaving the loading state stuck.
3. Guard the thenable check against null (typeof null === object) so callbacks that return null/void do not crash the wrapper.

## Verification

- ts:check: clean
- lint:check: clean
- vitest make-fetching: all 10 tests pass