### PR TITLE
feat: support mobx 7 and mobx-react-lite 5

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -40,8 +40,14 @@ jobs:
       - name: Check eslint
         run: npm run lint:check
 
-      - name: Test
+      - name: Test (MobX 7 / mobx-react-lite 5)
         run: npm run test -- --coverage
+
+      - name: Install MobX 6 / mobx-react-lite 4
+        run: npm install --no-save --ignore-scripts mobx@6.16.1 mobx-react-lite@4.1.1
+
+      - name: Test (MobX 6 / mobx-react-lite 4)
+        run: npm test
 
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ It is built for apps that want explicit store ownership, SSR support, persistenc
 npm i @lomray/react-mobx-manager @lomray/consistent-suspense
 ```
 
+Supports MobX 6 (>=6.9.0) and 7 with mobx-react-lite 3, 4, or 5; consumers must choose compatible peers, as mobx-react-lite 5 requires MobX 7 and React 18+ (React 17 remains supported with mobx-react-lite 3 or 4).
+
 ## Documentation
 
 Full documentation lives in [here](https://lomray-software.github.io/react-mobx-manager/)

--- a/__tests__/manager.ts
+++ b/__tests__/manager.ts
@@ -71,6 +71,42 @@ describe('Manager', () => {
     expect(manager.getStores().has('GlobalStore')).to.equal(true);
   });
 
+  it('should serialize mutations to auto-observable store classes', () => {
+    class CounterStore {
+      public static id = 'counter';
+      public static isGlobal = true;
+
+      public count = 0;
+      public nested = { values: [1] };
+
+      constructor() {
+        makeAutoObservable(this, {}, { autoBind: true });
+      }
+
+      public increment(): void {
+        this.count += 1;
+        this.nested.values.push(this.count + 1);
+      }
+    }
+
+    const manager = new Manager();
+    const store = manager.getStore(CounterStore)!;
+
+    try {
+      const initialState = manager.toJSON();
+
+      store.increment();
+
+      expect(manager.getStore(CounterStore)).to.equal(store);
+      expect(initialState).to.deep.equal({ counter: { count: 0, nested: { values: [1] } } });
+      expect(manager.toJSON()).to.deep.equal({
+        counter: { count: 1, nested: { values: [1, 2] } },
+      });
+    } finally {
+      manager.destroy();
+    }
+  });
+
   it('should mark creation failure if parent store is not found', () => {
     class RelativeStore {
       public libStoreId?: string;

--- a/docs/examples/recipes.md
+++ b/docs/examples/recipes.md
@@ -17,13 +17,13 @@ class UserStore {
   constructor() {
     makeObservable(this, {
       name: observable,
-      setName: action.bound,
+      setName: action,
     });
   }
 
-  public setName(name: string): void {
+  public setName = (name: string): void => {
     this.name = name;
-  }
+  };
 }
 
 const stores = {
@@ -50,13 +50,13 @@ class SomeOtherStore {
   constructor() {
     makeObservable(this, {
       value: observable,
-      setValue: action.bound,
+      setValue: action,
     });
   }
 
-  public setValue(value: string): void {
+  public setValue = (value: string): void => {
     this.value = value;
-  }
+  };
 }
 
 const stores = {

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -118,13 +118,13 @@ class UserStore {
 
     makeObservable(this, {
       name: observable,
-      setName: action.bound,
+      setName: action,
     });
   }
 
-  public setName(name: string): void {
+  public setName = (name: string): void => {
     this.name = name;
-  }
+  };
 }
 
 const stores = {
@@ -152,13 +152,13 @@ class SomeOtherStore {
   constructor() {
     makeObservable(this, {
       value: observable,
-      setValue: action.bound,
+      setValue: action,
     });
   }
 
-  public setValue(value: string): void {
+  public setValue = (value: string): void => {
     this.value = value;
-  }
+  };
 }
 
 const stores = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "husky": "^9.1.7",
         "jsdom": "^29.0.0",
         "lint-staged": "^16.4.0",
+        "mobx": "^7.0.3",
+        "mobx-react-lite": "^5.0.3",
         "prettier": "^3.8.1",
         "rollup": "^4.59.0",
         "rollup-plugin-copy": "^3.5.0",
@@ -44,7 +46,7 @@
         "hoist-non-react-statics": ">=3.3.2",
         "lodash": ">=4.17.21",
         "mobx": ">=6.9.0",
-        "mobx-react-lite": "^3 || ^4",
+        "mobx-react-lite": "^3 || ^4 || ^5",
         "react": "^19 || ^18 || ^17"
       }
     },
@@ -10122,40 +10124,29 @@
       "license": "MIT"
     },
     "node_modules/mobx": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
-      "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-7.0.3.tgz",
+      "integrity": "sha512-KopyyzqZ8xT1fqxFNl8ItKKMpGifRe2ySaNAHs80/cx0mL1bpJtJ46S+FSyzXKRjW0TODWj5zwq/Y9hUdJUy4w==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
       }
     },
     "node_modules/mobx-react-lite": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-4.1.1.tgz",
-      "integrity": "sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-5.0.3.tgz",
+      "integrity": "sha512-8qT/d/8Cg8ljt+heKhoFHNoqgedyeSGzdTixT0lgbFMMFlWfHUcXHZ8UD63eQi3ELjkxaH1VU07lXWhRwM0cVA==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "use-sync-external-store": "^1.4.0"
-      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
       },
       "peerDependencies": {
-        "mobx": "^6.9.0",
-        "react": "^16.8.0 || ^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
+        "mobx": "^7.0.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/ms": {
@@ -15656,16 +15647,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "husky": "^9.1.7",
     "jsdom": "^29.0.0",
     "lint-staged": "^16.4.0",
+    "mobx": "^7.0.3",
+    "mobx-react-lite": "^5.0.3",
     "prettier": "^3.8.1",
     "rollup": "^4.59.0",
     "rollup-plugin-copy": "^3.5.0",
@@ -77,7 +79,7 @@
     "hoist-non-react-statics": ">=3.3.2",
     "lodash": ">=4.17.21",
     "mobx": ">=6.9.0",
-    "mobx-react-lite": "^3 || ^4",
+    "mobx-react-lite": "^3 || ^4 || ^5",
     "react": "^19 || ^18 || ^17"
   },
   "overrides": {


### PR DESCRIPTION
## Goal

Support MobX 7 and mobx-react-lite 5 while keeping MobX 6 and mobx-react-lite 4 working.

Branch: `feature/mobx-7-support`, created from `origin/staging`. PR target: `staging`. Commit: `4d63b93` (`feat: support mobx 7 and mobx-react-lite 5`).

Staging is one commit ahead of prod. The first command run was:

```sh
git log --oneline origin/prod..origin/staging
```

```text
55860a4 chore: context7
```

## Changes

- Expand the mobx-react-lite peer to `^3 || ^4 || ^5`; retain `mobx >=6.9.0` and `react ^19 || ^18 || ^17`.
- Default development dependencies to `mobx ^7.0.3` and `mobx-react-lite ^5.0.3`, locked to 7.0.3 and 5.0.3. Regenerate the lockfile with one `npm install`; only these packages and their now-unused `use-sync-external-store` dependency changed.
- Run CI tests with the lockfile stack, then swap to `mobx@6.16.1 mobx-react-lite@4.1.1` using `npm install --no-save --ignore-scripts` and rerun the suite, following the [vite-ssr-boost runtime swap pattern](https://github.com/Lomray-Software/vite-ssr-boost/blob/staging/.github/workflows/react-compatibility.yml).
- Add a real observable-class regression test covering registration, mutation, nested snapshots, and serialization.
- Add the README support sentence and explain that consumers must select compatible peers: mobx-react-lite 5 requires MobX 7 and React 18+, while React 17 remains usable with mobx-react-lite 3 or 4.
- Replace four documentation uses of `action.bound` with `action` and arrow methods to preserve callback binding across both MobX majors.

Audited `src/`, tests, helpers, README, and docs. Runtime MobX imports are `reaction`, `toJS`, `runInAction`, `spy`, `untracked`, and `isObservableProp`; there is no `isObservable` import in this checkout. The only mobx-react-lite import is `observer`. The Vite helpers detect `makeObservable` / `makeAutoObservable` calls and inject store IDs. Their fixture strings are not executed as MobX calls. Runtime source changes were unnecessary.

TypeScript 4.9.5 and the existing React types compile successfully, so both remain unchanged. Installed `@types/react` is 18.3.28.

## Verification

Node `v22.23.2`, npm `10.9.8`. All final commands below exited successfully. No `--force`, `--legacy-peer-deps`, or hook bypass was used. No color workaround was needed.

**Dependency installation**

```sh
npm install
```

```text
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
npm warn deprecated rollup-plugin-ts@3.4.5: please use @rollup/plugin-typescript and rollup-plugin-dts instead

> @lomray/react-mobx-manager@1.0.0 prepare
> husky install

husky - install command is DEPRECATED

added 947 packages, and audited 1099 packages in 5s

319 packages are looking for funding
  run `npm fund` for details

25 vulnerabilities (1 low, 7 moderate, 15 high, 2 critical)

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
```

**MobX 7 / mobx-react-lite 5**

```sh
npm ci --ignore-scripts
```

```text
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
npm warn deprecated rollup-plugin-ts@3.4.5: please use @rollup/plugin-typescript and rollup-plugin-dts instead

added 947 packages, and audited 1099 packages in 6s

319 packages are looking for funding
  run `npm fund` for details

25 vulnerabilities (1 low, 7 moderate, 15 high, 2 critical)

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
```

```sh
npm ls mobx mobx-react-lite react typescript @types/react --depth=0
```

```text
@lomray/react-mobx-manager@1.0.0 /Users/mikhail/work/lomray/agent/react-mobx-manager
├── @types/react@18.3.28
├── mobx-react-lite@5.0.3
├── mobx@7.0.3
├── react@18.3.1
└── typescript@4.9.5
```

```sh
npm run build
```

```text
> @lomray/react-mobx-manager@1.0.0 build
> rollup -c

Browserslist: browsers data (caniuse-lite) is 7 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme

src/**/*.ts* → lib...
(!) Generated empty chunks
"types" and "plugins/dev-extension/hmr/types"
created lib in 4.2s
```

```sh
npm run ts:check
```

```text
> @lomray/react-mobx-manager@1.0.0 ts:check
> tsc --project ./tsconfig.checks.json --skipLibCheck --noemit
```

```sh
npm run lint:check
```

```text
> @lomray/react-mobx-manager@1.0.0 lint:check
> eslint "src/**/*.{ts,tsx,*.ts,*tsx}"
```

```sh
npm test
```

```text
> @lomray/react-mobx-manager@1.0.0 test
> vitest run


 RUN  v4.1.0 /Users/mikhail/work/lomray/agent/react-mobx-manager


 Test Files  25 passed (25)
      Tests  86 passed (86)
   Start at  23:33:44
   Duration  2.73s (transform 1.21s, setup 754ms, import 1.29s, tests 657ms, environment 20.44s)
```

**MobX 6 / mobx-react-lite 4, then restore the lockfile stack**

```sh
npm install --no-save --ignore-scripts mobx@6.16.1 mobx-react-lite@4.1.1 && npm test
```

```text
added 1 package, changed 2 packages, and audited 1100 packages in 2s

319 packages are looking for funding
  run `npm fund` for details

25 vulnerabilities (1 low, 7 moderate, 15 high, 2 critical)

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.

> @lomray/react-mobx-manager@1.0.0 test
> vitest run


 RUN  v4.1.0 /Users/mikhail/work/lomray/agent/react-mobx-manager


 Test Files  25 passed (25)
      Tests  86 passed (86)
   Start at  23:34:15
   Duration  2.33s (transform 1.15s, setup 991ms, import 977ms, tests 693ms, environment 16.92s)
```

```sh
npm ci --ignore-scripts
```

```text
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
npm warn deprecated rollup-plugin-ts@3.4.5: please use @rollup/plugin-typescript and rollup-plugin-dts instead

added 947 packages, and audited 1099 packages in 6s

319 packages are looking for funding
  run `npm fund` for details

25 vulnerabilities (1 low, 7 moderate, 15 high, 2 critical)

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
```

The original-lockfile preflight also reported the same 25 npm audit advisories. The build reported old Browserslist data and empty type-only chunks; build and type checking still passed.

**Built-package consumer smoke tests**

`rollup.config.js` outputs `lib`. Packed it from a temporary consumer directory:

```sh
npm pack /Users/mikhail/work/lomray/agent/react-mobx-manager/lib --silent
```

```text
husky - install command is DEPRECATED
.git can't be foundlomray-react-mobx-manager-1.0.0.tgz
```

The pack command succeeded; the copied package's existing Husky prepare script warned that `lib` has no `.git` directory.

Each consumer started with a private ESM package manifest in a temporary directory. Both ran this identical `smoke.mjs`, importing the built package's public entry point:

```js
import assert from 'node:assert/strict';
import { createRequire } from 'node:module';
import { Manager, StoreManagerProvider, withStores } from '@lomray/react-mobx-manager';
import { makeAutoObservable, reaction } from 'mobx';
import { enableStaticRendering } from 'mobx-react-lite';
import React from 'react';
import { renderToStaticMarkup } from 'react-dom/server';

const require = createRequire(import.meta.url);
const versions = Object.fromEntries(
  ['react', 'react-dom', 'mobx', 'mobx-react-lite'].map((name) => [
    name,
    require(`${name}/package.json`).version,
  ]),
);

class CounterStore {
  static id = 'counter';
  static isGlobal = true;
  count = 0;
  nested = { values: [1] };

  constructor() {
    makeAutoObservable(this, {}, { autoBind: true });
  }

  increment() {
    this.count += 1;
    this.nested.values.push(this.count + 1);
  }
}

const manager = new Manager();
const store = manager.getStore(CounterStore);
assert.ok(store instanceof CounterStore);
const initialState = manager.toJSON();
const changes = [];
const dispose = reaction(() => manager.toJSON(), (state) => changes.push(state));

try {
  const { increment } = store;
  increment();
  const state = manager.toJSON();
  assert.deepEqual(initialState, { counter: { count: 0, nested: { values: [1] } } });
  assert.deepEqual(state, { counter: { count: 1, nested: { values: [1, 2] } } });
  assert.deepEqual(changes, [state]);
  assert.equal(manager.getStore(CounterStore), store);

  enableStaticRendering(true);
  const Counter = withStores(
    ({ counter }) => React.createElement('span', null, counter.count),
    { counter: CounterStore },
  );
  const html = renderToStaticMarkup(
    React.createElement(StoreManagerProvider, { storeManager: manager }, React.createElement(Counter)),
  );
  assert.equal(html, '<span>1</span>');

  console.log(JSON.stringify(versions));
  console.log(`manager.toJSON() = ${JSON.stringify(state)}`);
  console.log(`reaction updates = ${changes.length}`);
  console.log(`withStores SSR = ${html}`);
  console.log('PASS');
} finally {
  dispose();
  manager.destroy();
  enableStaticRendering(false);
}
```

```sh
npm install --ignore-scripts ./lomray-react-mobx-manager-1.0.0.tgz react@19.2.8 react-dom@19.2.8 mobx@7.0.3 mobx-react-lite@5.0.3 @lomray/consistent-suspense @lomray/event-manager hoist-non-react-statics lodash
```

```text
added 11 packages, and audited 12 packages in 1s

2 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

```sh
node smoke.mjs
```

```text
{"react":"19.2.8","react-dom":"19.2.8","mobx":"7.0.3","mobx-react-lite":"5.0.3"}
manager.toJSON() = {"counter":{"count":1,"nested":{"values":[1,2]}}}
reaction updates = 1
withStores SSR = <span>1</span>
PASS
```

In a second empty consumer directory, using the same archive and script:

```sh
npm install --ignore-scripts ../consumer/lomray-react-mobx-manager-1.0.0.tgz react@19.2.8 react-dom@19.2.8 mobx@6.16.1 mobx-react-lite@4.1.1 @lomray/consistent-suspense @lomray/event-manager hoist-non-react-statics lodash && node smoke.mjs
```

```text
added 12 packages, and audited 13 packages in 521ms

2 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
{"react":"19.2.8","react-dom":"19.2.8","mobx":"6.16.1","mobx-react-lite":"4.1.1"}
manager.toJSON() = {"counter":{"count":1,"nested":{"values":[1,2]}}}
reaction updates = 1
withStores SSR = <span>1</span>
PASS
```

**Commit and final review**

Verified the branch against `.husky/commit-msg` and the requested name before committing. Husky ran ESLint, Prettier, and commitlint. An initial test-only unbound-method lint failure was corrected, and both dependency suites were rerun before the successful commit.

The existing commit-msg hook emitted a shell warning in its branch comparison; the separate explicit branch-name validation passed.

```sh
git commit -m "feat: support mobx 7 and mobx-react-lite 5"
```

```text
husky - DEPRECATED

Please remove the following two lines from .husky/pre-commit:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0

[STARTED] Backing up original state...
[COMPLETED] Backed up original state in git stash (75c82f2)
[STARTED] Running tasks for staged files...
[STARTED] .lintstagedrc.js — 7 files
[STARTED] (src|__tests__|__mocks__|__helpers__)/**/*.{ts,tsx,js} — 1 file
[STARTED] eslint --max-warnings=0
[COMPLETED] eslint --max-warnings=0
[STARTED] prettier --write
[COMPLETED] prettier --write
[COMPLETED] (src|__tests__|__mocks__|__helpers__)/**/*.{ts,tsx,js} — 1 file
[COMPLETED] .lintstagedrc.js — 7 files
[COMPLETED] Running tasks for staged files...
[STARTED] Applying modifications from tasks...
[COMPLETED] Applying modifications from tasks...
[STARTED] Cleaning up temporary files...
[COMPLETED] Cleaning up temporary files...
husky - DEPRECATED

Please remove the following two lines from .husky/commit-msg:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0

.husky/commit-msg: line 17: [: =~: binary operator expected
[feature/mobx-7-support 4d63b93] feat: support mobx 7 and mobx-react-lite 5
 7 files changed, 73 insertions(+), 46 deletions(-)
```

```sh
git diff --stat origin/staging...HEAD
```

```text
.github/workflows/pr-check.yml |  8 +++++++-
 README.md                      |  2 ++
 __tests__/manager.ts           | 36 +++++++++++++++++++++++++++++++++
 docs/examples/recipes.md       | 12 +++++------
 docs/guide/getting-started.md  | 12 +++++------
 package-lock.json              | 45 ++++++++++++------------------------------
 package.json                   |  4 +++-
 7 files changed, 73 insertions(+), 46 deletions(-)
```

`git diff --check` passed. Verified that the lockfile contains no unrelated dependency changes and that the working installation is restored to MobX 7.0.3 / mobx-react-lite 5.0.3. `PR_DESCRIPTION.md` is the only untracked file and is not committed.

## Not run

- Push, pull request creation, or `gh`, as instructed.
- GitHub-hosted CI, coverage reporting, SonarCloud, and the documentation site build.
- React 17 and mobx-react-lite 3 runtime tests; the requested checks covered MobX 7 / lite 5 and MobX 6 / lite 4, plus React 19.2.8 consumers.

## Open questions

None. All requested acceptance criteria are met.
