### PR TITLE
feat: support mobx 7 and mobx-react-lite 5

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -40,8 +40,14 @@ jobs:
       - name: Check eslint
         run: npm run lint:check
 
-      - name: Test
+      - name: Test (MobX 7 / mobx-react-lite 5)
         run: npm run test -- --coverage
+
+      - name: Install MobX 6 / mobx-react-lite 4
+        run: npm install --no-save --ignore-scripts mobx@6.16.1 mobx-react-lite@4.1.1
+
+      - name: Test (MobX 6 / mobx-react-lite 4)
+        run: npm test
 
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ It is built for apps that want explicit store ownership, SSR support, persistenc
 npm i @lomray/react-mobx-manager @lomray/consistent-suspense
 ```
 
+Supports MobX 6 (>=6.9.0) and 7 with mobx-react-lite 3, 4, or 5; consumers must choose compatible peers, as mobx-react-lite 5 requires MobX 7 and React 18+ (React 17 remains supported with mobx-react-lite 3 or 4).
+
 ## Documentation
 
 Full documentation lives in [here](https://lomray-software.github.io/react-mobx-manager/)

--- a/__tests__/manager.ts
+++ b/__tests__/manager.ts
@@ -71,6 +71,42 @@ describe('Manager', () => {
     expect(manager.getStores().has('GlobalStore')).to.equal(true);
   });
 
+  it('should serialize mutations to auto-observable store classes', () => {
+    class CounterStore {
+      public static id = 'counter';
+      public static isGlobal = true;
+
+      public count = 0;
+      public nested = { values: [1] };
+
+      constructor() {
+        makeAutoObservable(this, {}, { autoBind: true });
+      }
+
+      public increment(): void {
+        this.count += 1;
+        this.nested.values.push(this.count + 1);
+      }
+    }
+
+    const manager = new Manager();
+    const store = manager.getStore(CounterStore)!;
+
+    try {
+      const initialState = manager.toJSON();
+
+      store.increment();
+
+      expect(manager.getStore(CounterStore)).to.equal(store);
+      expect(initialState).to.deep.equal({ counter: { count: 0, nested: { values: [1] } } });
+      expect(manager.toJSON()).to.deep.equal({
+        counter: { count: 1, nested: { values: [1, 2] } },
+      });
+    } finally {
+      manager.destroy();
+    }
+  });
+
   it('should mark creation failure if parent store is not found', () => {
     class RelativeStore {
       public libStoreId?: string;

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/lomray-software/react-mobx-manager",
+  "public_key": "pk_9IAtRK9ehH9s9ktsgMjAJ"
+}

--- a/docs/examples/recipes.md
+++ b/docs/examples/recipes.md
@@ -17,13 +17,13 @@ class UserStore {
   constructor() {
     makeObservable(this, {
       name: observable,
-      setName: action.bound,
+      setName: action,
     });
   }
 
-  public setName(name: string): void {
+  public setName = (name: string): void => {
     this.name = name;
-  }
+  };
 }
 
 const stores = {
@@ -50,13 +50,13 @@ class SomeOtherStore {
   constructor() {
     makeObservable(this, {
       value: observable,
-      setValue: action.bound,
+      setValue: action,
     });
   }
 
-  public setValue(value: string): void {
+  public setValue = (value: string): void => {
     this.value = value;
-  }
+  };
 }
 
 const stores = {

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -118,13 +118,13 @@ class UserStore {
 
     makeObservable(this, {
       name: observable,
-      setName: action.bound,
+      setName: action,
     });
   }
 
-  public setName(name: string): void {
+  public setName = (name: string): void => {
     this.name = name;
-  }
+  };
 }
 
 const stores = {
@@ -152,13 +152,13 @@ class SomeOtherStore {
   constructor() {
     makeObservable(this, {
       value: observable,
-      setValue: action.bound,
+      setValue: action,
     });
   }
 
-  public setValue(value: string): void {
+  public setValue = (value: string): void => {
     this.value = value;
-  }
+  };
 }
 
 const stores = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "husky": "^9.1.7",
         "jsdom": "^29.0.0",
         "lint-staged": "^16.4.0",
+        "mobx": "^7.0.3",
+        "mobx-react-lite": "^5.0.3",
         "prettier": "^3.8.1",
         "rollup": "^4.59.0",
         "rollup-plugin-copy": "^3.5.0",
@@ -44,7 +46,7 @@
         "hoist-non-react-statics": ">=3.3.2",
         "lodash": ">=4.17.21",
         "mobx": ">=6.9.0",
-        "mobx-react-lite": "^3 || ^4",
+        "mobx-react-lite": "^3 || ^4 || ^5",
         "react": "^19 || ^18 || ^17"
       }
     },
@@ -10122,40 +10124,29 @@
       "license": "MIT"
     },
     "node_modules/mobx": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
-      "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-7.0.3.tgz",
+      "integrity": "sha512-KopyyzqZ8xT1fqxFNl8ItKKMpGifRe2ySaNAHs80/cx0mL1bpJtJ46S+FSyzXKRjW0TODWj5zwq/Y9hUdJUy4w==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
       }
     },
     "node_modules/mobx-react-lite": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-4.1.1.tgz",
-      "integrity": "sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-5.0.3.tgz",
+      "integrity": "sha512-8qT/d/8Cg8ljt+heKhoFHNoqgedyeSGzdTixT0lgbFMMFlWfHUcXHZ8UD63eQi3ELjkxaH1VU07lXWhRwM0cVA==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "use-sync-external-store": "^1.4.0"
-      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
       },
       "peerDependencies": {
-        "mobx": "^6.9.0",
-        "react": "^16.8.0 || ^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
+        "mobx": "^7.0.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/ms": {
@@ -15656,16 +15647,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "husky": "^9.1.7",
     "jsdom": "^29.0.0",
     "lint-staged": "^16.4.0",
+    "mobx": "^7.0.3",
+    "mobx-react-lite": "^5.0.3",
     "prettier": "^3.8.1",
     "rollup": "^4.59.0",
     "rollup-plugin-copy": "^3.5.0",
@@ -77,7 +79,7 @@
     "hoist-non-react-statics": ">=3.3.2",
     "lodash": ">=4.17.21",
     "mobx": ">=6.9.0",
-    "mobx-react-lite": "^3 || ^4",
+    "mobx-react-lite": "^3 || ^4 || ^5",
     "react": "^19 || ^18 || ^17"
   },
   "overrides": {


### PR DESCRIPTION
Promote staging to prod: widen the mobx-react-lite peer range to ^3 || ^4 || ^5 (MobX 7 support), CI tests on both MobX majors, docs updated to APIs present in MobX 6 and 7, plus the context7 docs chore already on staging.