### PR TITLE
fix: runtime, persistence, id generation and packaging fixes from the audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ Made with 💚
 Published under [MIT License](./LICENSE).
 
 With `shouldInit`, `StoreManagerProvider` renders only the fallback (or nothing) until initialization finishes. Consumers needing immediate content should initialize the manager before rendering and omit `shouldInit`, as the Vite template does.
+
+`makeFetching` is available as a named root export. Public subpaths support both extensionless imports and explicit `.js` paths (use `/index.js` for directory entries), including native Node ESM consumers.

--- a/README.md
+++ b/README.md
@@ -55,3 +55,5 @@ Full documentation lives in [here](https://lomray-software.github.io/react-mobx-
 Made with 💚
 
 Published under [MIT License](./LICENSE).
+
+With `shouldInit`, `StoreManagerProvider` renders only the fallback (or nothing) until initialization finishes. Consumers needing immediate content should initialize the manager before rendering and omit `shouldInit`, as the Vite template does.

--- a/__probes__/README.md
+++ b/__probes__/README.md
@@ -1,0 +1,21 @@
+# Packed-package regressions
+
+Copy these fixtures to a temporary ESM consumer and install the tarball produced by
+`npm pack ./lib`, React/react-dom 19.2.8, MobX 7, mobx-react-lite 5, jsdom, Vite 8,
+TypeScript 6.0.3, and the corresponding React/Node/lodash/hoist-non-react-statics types.
+Run from that temporary directory:
+
+```sh
+node vite-cache.mjs
+node ssr-isolated.mjs
+node provider-init.mjs
+node package-imports.mjs
+npx --no-install tsc -p tsconfig.bundler.json --noEmit
+npx --no-install tsc -p tsconfig.node16.json --noEmit
+```
+
+The Vite probe creates two builds with a retained cache and verifies rejection of a
+duplicate cache. It removes the temporary consumer's manager ID cache. The SSR probe
+uses separate server and client processes, with zero hydration warnings required for
+scalar, shortened-array, and streamed suspense state. Both TypeScript configurations
+check extensionless and explicit `.js` consumers with `skipLibCheck: false`.

--- a/__probes__/consumer-explicit.tsx
+++ b/__probes__/consumer-explicit.tsx
@@ -51,3 +51,7 @@ void [
   connectHmrRuntime,
   ManagerHmr,
 ];
+
+api.Manager.persistStore(Store, 'example');
+// @ts-expect-error A persistence ID is required.
+api.Manager.persistStore(Store);

--- a/__probes__/consumer-explicit.tsx
+++ b/__probes__/consumer-explicit.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { makeFetching as rootMakeFetching } from '@lomray/react-mobx-manager';
+import * as api from '@lomray/react-mobx-manager';
+import SuspenseQuery from '@lomray/react-mobx-manager/suspense-query.js';
+import ManagerStream from '@lomray/react-mobx-manager/manager-stream.js';
+import makeFetching from '@lomray/react-mobx-manager/make-fetching.js';
+import LocalStorage from '@lomray/react-mobx-manager/storages/local-storage.js';
+import SessionStorage from '@lomray/react-mobx-manager/storages/session-storage.js';
+import CookieStorage from '@lomray/react-mobx-manager/storages/cookie-storage.js';
+import AsyncStorage from '@lomray/react-mobx-manager/storages/async-storage.js';
+import CombinedStorage from '@lomray/react-mobx-manager/storages/combined-storage.js';
+import vitePlugin from '@lomray/react-mobx-manager/plugins/vite/index.js';
+import connectDevExtension from '@lomray/react-mobx-manager/plugins/dev-extension/index.js';
+import {
+  connectViteHmr,
+  connectWebpackHmr,
+  connectReactNativeHmr,
+  connectHmrRuntime,
+  ManagerHmr,
+} from '@lomray/react-mobx-manager/plugins/dev-extension/hmr/index.js';
+import { defineConfig } from 'vite';
+class Store {
+  value = 1;
+}
+const View = api.withStores(({ store }: { store: Store }) => <p>{store.value}</p>, {
+  store: Store,
+});
+const manager = new api.Manager();
+const tree = (
+  <api.StoreManagerProvider storeManager={manager}>
+    <View />
+  </api.StoreManagerProvider>
+);
+const config = defineConfig({ plugins: [vitePlugin()] });
+void [
+  rootMakeFetching,
+  tree,
+  config,
+  SuspenseQuery,
+  ManagerStream,
+  makeFetching,
+  LocalStorage,
+  SessionStorage,
+  CookieStorage,
+  AsyncStorage,
+  CombinedStorage,
+  connectDevExtension,
+  connectViteHmr,
+  connectWebpackHmr,
+  connectReactNativeHmr,
+  connectHmrRuntime,
+  ManagerHmr,
+];

--- a/__probes__/consumer.tsx
+++ b/__probes__/consumer.tsx
@@ -51,3 +51,7 @@ void [
   connectHmrRuntime,
   ManagerHmr,
 ];
+
+api.Manager.persistStore(Store, 'example');
+// @ts-expect-error A persistence ID is required.
+api.Manager.persistStore(Store);

--- a/__probes__/consumer.tsx
+++ b/__probes__/consumer.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { makeFetching as rootMakeFetching } from '@lomray/react-mobx-manager';
+import * as api from '@lomray/react-mobx-manager';
+import SuspenseQuery from '@lomray/react-mobx-manager/suspense-query';
+import ManagerStream from '@lomray/react-mobx-manager/manager-stream';
+import makeFetching from '@lomray/react-mobx-manager/make-fetching';
+import LocalStorage from '@lomray/react-mobx-manager/storages/local-storage';
+import SessionStorage from '@lomray/react-mobx-manager/storages/session-storage';
+import CookieStorage from '@lomray/react-mobx-manager/storages/cookie-storage';
+import AsyncStorage from '@lomray/react-mobx-manager/storages/async-storage';
+import CombinedStorage from '@lomray/react-mobx-manager/storages/combined-storage';
+import vitePlugin from '@lomray/react-mobx-manager/plugins/vite';
+import connectDevExtension from '@lomray/react-mobx-manager/plugins/dev-extension';
+import {
+  connectViteHmr,
+  connectWebpackHmr,
+  connectReactNativeHmr,
+  connectHmrRuntime,
+  ManagerHmr,
+} from '@lomray/react-mobx-manager/plugins/dev-extension/hmr';
+import { defineConfig } from 'vite';
+class Store {
+  value = 1;
+}
+const View = api.withStores(({ store }: { store: Store }) => <p>{store.value}</p>, {
+  store: Store,
+});
+const manager = new api.Manager();
+const tree = (
+  <api.StoreManagerProvider storeManager={manager}>
+    <View />
+  </api.StoreManagerProvider>
+);
+const config = defineConfig({ plugins: [vitePlugin()] });
+void [
+  rootMakeFetching,
+  tree,
+  config,
+  SuspenseQuery,
+  ManagerStream,
+  makeFetching,
+  LocalStorage,
+  SessionStorage,
+  CookieStorage,
+  AsyncStorage,
+  CombinedStorage,
+  connectDevExtension,
+  connectViteHmr,
+  connectWebpackHmr,
+  connectReactNativeHmr,
+  connectHmrRuntime,
+  ManagerHmr,
+];

--- a/__probes__/docs-probes.mjs
+++ b/__probes__/docs-probes.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import * as hmr from '@lomray/react-mobx-manager/plugins/dev-extension/hmr/index.js';
+import IdGenerator from '@lomray/react-mobx-manager/plugins/vite/id-generator.js';
+import { Generator } from '@lomray/react-mobx-manager/plugins/helpers.js';
+const code = '/** @mobx-store */ class Tagged { value = 1; }';
+const service = new Generator('/audit');
+const plugin = IdGenerator({ root: '/audit' });
+console.log(
+  'HMR barrel: ' +
+    JSON.stringify({
+      default: typeof hmr.default,
+      connectHmrRuntime: typeof hmr.connectHmrRuntime,
+    }),
+);
+console.log(
+  'JSDoc-only store: ' +
+    JSON.stringify({
+      helperMatch: service.matchMobxStore(code),
+      pluginResult: plugin.transform.call({}, code, '/audit/tagged.js') ?? null,
+    }),
+);
+assert.equal(typeof hmr.default, 'undefined');
+assert.equal(service.matchMobxStore(code), 'Tagged');
+assert.match(plugin.transform.call({}, code, '/audit/tagged.js').code, /static id =/);
+assert.equal(typeof hmr.connectHmrRuntime, 'function');

--- a/__probes__/package-imports.mjs
+++ b/__probes__/package-imports.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { readdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeFetching } from '@lomray/react-mobx-manager';
+import fetching from '@lomray/react-mobx-manager/make-fetching.js';
+
+const name = '@lomray/react-mobx-manager';
+const root = dirname(fileURLToPath(import.meta.resolve(`${name}/package.json`)));
+const files = readdirSync(root, { recursive: true }).filter((file) => file.endsWith('.js'));
+for (const file of files) {
+  const explicit = await import(`${name}/${file}`);
+  const extensionless = await import(`${name}/${file.slice(0, -3)}`);
+  assert.equal(extensionless, explicit);
+}
+for (const entry of ['plugins/vite', 'plugins/dev-extension', 'plugins/dev-extension/hmr']) {
+  assert.equal(await import(`${name}/${entry}`), await import(`${name}/${entry}/index.js`));
+}
+const metadata = await import(`${name}/package.json`, { with: { type: 'json' } });
+assert.equal(metadata.default.name, name);
+assert.equal(typeof makeFetching, 'function');
+assert.equal(makeFetching, fetching);
+console.log(
+  `Native Node ESM: ${files.length} .js paths + ${files.length} extensionless paths + 3 directory aliases + root + package.json passed`,
+);
+console.log('makeFetching root export: function (matches subpath default)');

--- a/__probes__/provider-init.mjs
+++ b/__probes__/provider-init.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import React, { act, createRef } from 'react';
+import { createRoot } from 'react-dom/client';
+import { makeAutoObservable } from 'mobx';
+import { Manager, StoreManagerProvider, withStores } from '@lomray/react-mobx-manager';
+import { ConsistentSuspenseProvider } from '@lomray/consistent-suspense';
+import { JSDOM } from 'jsdom';
+const h = React.createElement;
+const dom = new JSDOM('<div id="root"></div>', { url: 'https://audit.test' });
+Object.assign(globalThis, {
+  window: dom.window,
+  document: dom.window.document,
+  HTMLElement: dom.window.HTMLElement,
+  IS_REACT_ACT_ENVIRONMENT: true,
+});
+class UserStore {
+  name = 'default';
+  constructor() {
+    makeAutoObservable(this);
+  }
+}
+Manager.persistStore(UserStore, 'user');
+const View = withStores(({ store }) => h('p', null, store.name), { store: UserStore });
+for (const hasFallback of [false, true]) {
+  let finishInit;
+  const manager = new Manager({
+    storage: {
+      get: () =>
+        new Promise((resolve) => {
+          finishInit = () => resolve({ user: { name: 'persisted' } });
+        }),
+      set: () => {},
+      flush: () => {},
+    },
+  });
+  const root = createRoot(document.getElementById('root'));
+  await act(async () =>
+    root.render(
+      h(
+        ConsistentSuspenseProvider,
+        null,
+        h(
+          StoreManagerProvider,
+          {
+            storeManager: manager,
+            shouldInit: true,
+            ...(hasFallback ? { fallback: h('i', null, 'loading') } : {}),
+          },
+          h(View),
+        ),
+      ),
+    ),
+  );
+  assert.equal(document.getElementById('root').textContent, hasFallback ? 'loading' : '');
+  assert.equal(manager.getStores().size, 0);
+  await act(async () => {
+    finishInit();
+  });
+  const actual = document.getElementById('root').textContent;
+  console.log(
+    JSON.stringify({
+      shouldInit: true,
+      hasFallback,
+      storage: manager.storage.getStoreData({ libStoreId: 'user' }),
+      rendered: actual,
+    }),
+  );
+  assert.equal(actual, 'persisted');
+  await act(async () => root.unmount());
+  manager.destroy();
+}
+const manager = new Manager();
+const ref = createRef();
+const RefView = withStores(({ ref: inputRef }) => h('input', { ref: inputRef }), {
+  store: UserStore,
+});
+const root = createRoot(document.getElementById('root'));
+await act(async () =>
+  root.render(
+    h(
+      ConsistentSuspenseProvider,
+      null,
+      h(StoreManagerProvider, { storeManager: manager }, h(RefView, { ref })),
+    ),
+  ),
+);
+assert.equal(ref.current?.tagName, 'INPUT');
+console.log('React 19 ref-as-prop through withStores: INPUT');
+await act(async () => root.unmount());
+manager.destroy();
+dom.window.close();

--- a/__probes__/ssr-isolated.mjs
+++ b/__probes__/ssr-isolated.mjs
@@ -1,0 +1,223 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { Writable } from 'node:stream';
+import { spawnSync } from 'node:child_process';
+const [phase, scenario] = process.argv.slice(2);
+if (!phase) {
+  for (const scenario of ['scalar', 'array', 'stream'])
+    for (const phase of ['server', 'client']) {
+      const r = spawnSync(process.execPath, [import.meta.filename, phase, scenario], {
+        encoding: 'utf8',
+      });
+      process.stdout.write(r.stdout);
+      process.stderr.write(r.stderr);
+      assert.equal(r.status, 0);
+    }
+} else {
+  const React = await import('react');
+  const { act } = React;
+  const h = React.createElement;
+  const { makeAutoObservable, runInAction } = await import('mobx');
+  const { enableStaticRendering } = await import('mobx-react-lite');
+  const { Manager, StoreManagerProvider, withStores } = await import('@lomray/react-mobx-manager');
+  const { default: ManagerStream } = await import('@lomray/react-mobx-manager/manager-stream.js');
+  const { default: SuspenseQuery } = await import('@lomray/react-mobx-manager/suspense-query.js');
+  const { ConsistentSuspenseProvider, Suspense } = await import('@lomray/consistent-suspense');
+  let fetches = 0;
+  class Store {
+    items = ['default-a', 'default-b'];
+    count = 0;
+    value = 'pending';
+    suspense;
+    constructor() {
+      this.suspense = new SuspenseQuery(this);
+      makeAutoObservable(this, { suspense: false });
+    }
+    load = () =>
+      this.suspense.query(() => {
+        fetches++;
+        return new Promise((resolve) =>
+          setTimeout(() => {
+            runInAction(() => {
+              this.value = 'streamed';
+            });
+            resolve();
+          }, 40),
+        );
+      });
+  }
+  const Child = withStores(
+    ({ store }) => {
+      if (scenario === 'stream') store.load();
+      return h(
+        'p',
+        null,
+        scenario === 'array'
+          ? store.items.join(',')
+          : scenario === 'scalar'
+            ? String(store.count)
+            : store.value,
+      );
+    },
+    { store: Store },
+  );
+  const wrap = (manager) =>
+    h(
+      React.StrictMode,
+      null,
+      h(
+        ConsistentSuspenseProvider,
+        null,
+        h(
+          StoreManagerProvider,
+          { storeManager: manager },
+          h(
+            'main',
+            null,
+            h('header', null, 'shell|'),
+            h(Suspense, { fallback: h('i', null, 'loading') }, h(Child)),
+          ),
+        ),
+      ),
+    );
+  const fixturePath = new URL('./ssr-' + scenario + '.json', import.meta.url);
+  if (phase === 'server') {
+    enableStaticRendering(true);
+    const manager = new Manager({ options: { shouldDisablePersist: true } });
+    const { renderToString, renderToPipeableStream } = await import('react-dom/server');
+    let html = '',
+      state,
+      takes = 0,
+      chunks = 0;
+    if (scenario !== 'stream') {
+      renderToString(wrap(manager));
+      runInAction(() => {
+        const store = [...manager.getStores().values()][0];
+        store.count = 42;
+        store.items = ['server'];
+      });
+      html = renderToString(wrap(manager));
+      state = JSON.parse(JSON.stringify(manager.toJSON()));
+    } else {
+      const { StreamSuspense } = await import('@lomray/consistent-suspense/server/index.js');
+      const ms = new ManagerStream(manager);
+      const ss = StreamSuspense.create((id) => {
+        takes++;
+        return ms.take(id);
+      });
+      await new Promise((resolve, reject) => {
+        const dest = new Writable({
+          write(chunk, enc, next) {
+            const raw = chunk.toString();
+            chunks++;
+            html += ss.analyze(raw) ?? raw;
+            next();
+          },
+        });
+        dest.on('finish', resolve);
+        const stream = renderToPipeableStream(wrap(manager), {
+          onShellReady() {
+            state = JSON.parse(JSON.stringify(manager.toJSON()));
+            stream.pipe(dest);
+          },
+          onError: reject,
+        });
+      });
+    }
+    const result = {
+      html,
+      state,
+      ids: [...manager.getStores().keys()],
+      finalState: manager.toJSON(),
+      takes,
+      chunks,
+      fetches,
+    };
+    fs.writeFileSync(fixturePath, JSON.stringify(result));
+    console.log(
+      JSON.stringify({
+        phase,
+        scenario,
+        ids: result.ids,
+        chunks,
+        managerStreamCalls: takes,
+        statePush: html.includes('window.mbxM.push'),
+        fetches,
+      }),
+    );
+    manager.destroy();
+  } else {
+    const fixture = JSON.parse(fs.readFileSync(fixturePath));
+    const { JSDOM } = await import('jsdom');
+    const dom = new JSDOM('<!doctype html><div id="root">' + fixture.html + '</div>', {
+      url: 'https://audit.test',
+      runScripts: 'dangerously',
+      pretendToBeVisual: true,
+    });
+    Object.assign(globalThis, {
+      window: dom.window,
+      document: dom.window.document,
+      HTMLElement: dom.window.HTMLElement,
+      IS_REACT_ACT_ENVIRONMENT: true,
+    });
+    await new Promise((r) => setTimeout(r, 60));
+    const container = document.getElementById('root');
+    const visible = () => container.querySelector('main').textContent;
+    const before = visible();
+    const manager = new Manager({
+      initState: fixture.state,
+      options: { shouldDisablePersist: true },
+    });
+    enableStaticRendering(false);
+    const { hydrateRoot } = await import('react-dom/client');
+    const errors = [];
+    const original = console.error;
+    console.error = (...args) => errors.push(args.map(String).join(' '));
+    let root;
+    await act(async () => {
+      root = hydrateRoot(container, wrap(manager), {
+        onRecoverableError: (e) => errors.push(e.message),
+      });
+    });
+    for (let i = 0; i < 4; i++)
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 60));
+      });
+    console.error = original;
+    const after = visible();
+    console.log(
+      JSON.stringify({
+        phase,
+        scenario,
+        serverText: before,
+        clientText: after,
+        ids: [...manager.getStores().keys()],
+        hydrationErrors: errors.length,
+        errors: errors.map((s) => s.split('\n')[0]),
+        fetches,
+        clientState: manager.toJSON(),
+      }),
+    );
+    if (scenario === 'stream') {
+      assert.equal(fixture.takes, 1);
+      assert.equal(fixture.chunks, 2);
+      assert.equal(errors.length, 0);
+      assert.equal(fetches, 0);
+      assert.equal(before, after);
+      assert.deepEqual(JSON.parse(JSON.stringify(manager.toJSON())), fixture.finalState);
+    }
+    if (scenario === 'scalar') {
+      assert.equal(errors.length, 0);
+      assert.equal(before, after);
+      assert.deepEqual([...manager.getStores().keys()], fixture.ids);
+    }
+    if (scenario === 'array') {
+      assert.equal(errors.length, 0);
+      assert.equal(before, after);
+      assert.deepEqual(JSON.parse(JSON.stringify(manager.toJSON())), fixture.finalState);
+    }
+    await act(async () => root.unmount());
+    manager.destroy();
+    dom.window.close();
+  }
+}

--- a/__probes__/tsconfig.bundler.json
+++ b/__probes__/tsconfig.bundler.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": false,
+    "types": [
+      "node",
+      "react",
+      "react-dom"
+    ],
+    "noEmit": true
+  },
+  "files": [
+    "consumer.tsx",
+    "consumer-explicit.tsx"
+  ]
+}

--- a/__probes__/tsconfig.node16.json
+++ b/__probes__/tsconfig.node16.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "target": "ES2022",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": false,
+    "types": [
+      "node",
+      "react",
+      "react-dom"
+    ],
+    "noEmit": true
+  },
+  "files": [
+    "consumer.tsx",
+    "consumer-explicit.tsx"
+  ]
+}

--- a/__probes__/vite-cache.mjs
+++ b/__probes__/vite-cache.mjs
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { build } from 'vite';
+import plugin from '@lomray/react-mobx-manager/plugins/vite/index.js';
+const root = path.resolve('vite-app');
+fs.mkdirSync(root, { recursive: true });
+fs.rmSync('node_modules/.cache/@lomray/react-mobx-manager/store-ids.json', { force: true });
+fs.writeFileSync(
+  root + '/a.js',
+  'import {makeAutoObservable} from "mobx";export class A {static isGlobal=true;value=1; constructor(){makeAutoObservable(this);} }',
+);
+fs.writeFileSync(root + '/entry.js', 'export {A} from "./a.js";');
+const compile = async () => {
+  const result = await build({
+    root,
+    configFile: false,
+    logLevel: 'silent',
+    plugins: plugin(),
+    build: {
+      write: false,
+      minify: false,
+      lib: { entry: root + '/entry.js', formats: ['es'] },
+      rollupOptions: { external: ['mobx'] },
+    },
+  });
+  return result[0].output.find((o) => o.type === 'chunk').code;
+};
+const a = await compile();
+fs.writeFileSync(
+  root + '/b.js',
+  'import {makeAutoObservable} from "mobx";export class B {static isGlobal=true;value=2; constructor(){makeAutoObservable(this);} }',
+);
+fs.writeFileSync(root + '/entry.js', 'export {A} from "./a.js";export {B} from "./b.js";');
+const b = await compile();
+const ids = (s) => [...s.matchAll(/static id = ["'](.*?)["']/g)].map((m) => m[1]);
+console.log('Vite 8.2.2 first build static IDs: ' + JSON.stringify(ids(a)));
+console.log('Vite 8.2.2 second build static IDs: ' + JSON.stringify(ids(b)));
+assert.deepEqual(ids(a), ['Sa']);
+assert.deepEqual(ids(b), ['Sa', 'Sb']);
+
+fs.writeFileSync('vite-output.mjs', b);
+const { A, B } = await import('./vite-output.mjs');
+const { Manager } = await import('@lomray/react-mobx-manager');
+const manager = new Manager();
+const storeA = manager.getStore(A),
+  storeB = manager.getStore(B);
+console.log(
+  'Global store lookup: ' +
+    JSON.stringify({
+      sameInstance: storeA === storeB,
+      requestedBValue: storeB.value,
+      expectedBValue: 2,
+    }),
+);
+assert.notEqual(storeA, storeB);
+assert.equal(storeB.value, 2);
+manager.destroy();
+
+const cacheFile = 'node_modules/.cache/@lomray/react-mobx-manager/store-ids.json';
+const cache = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
+cache[1][1].storeId = cache[0][1].storeId;
+fs.writeFileSync(cacheFile, JSON.stringify(cache));
+await assert.rejects(compile, /Duplicate store ID/);
+fs.rmSync(cacheFile);
+console.log('Duplicate loaded cache rejected');

--- a/__tests__/context.tsx
+++ b/__tests__/context.tsx
@@ -87,6 +87,24 @@ describe('context', () => {
     expect(providerResult).to.equal(fallbackNode);
     sinon.assert.calledOnce(storeManager.init);
 
+    for (const fallback of [undefined, null, false, 0, ''] as const) {
+      expect(
+        StoreManagerProvider({
+          storeManager: storeManager as never,
+          shouldInit: true,
+          fallback: fallback as never,
+          children: childNode,
+        }),
+      ).to.equal(fallback ?? null);
+    }
+
+    expect(
+      StoreManagerProvider({
+        storeManager: storeManager as never,
+        children: childNode,
+      }),
+    ).to.equal(childNode);
+
     contexts[0].value = storeManager;
     contexts[1].value = 'parent-id';
 

--- a/__tests__/deep-merge.ts
+++ b/__tests__/deep-merge.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import { observable, runInAction } from 'mobx';
+import { describe, it } from 'vitest';
+import deepMerge from '@src/deep-merge';
+
+describe('deepMerge', () => {
+  it('should replace shorter, empty and nested arrays while preserving the target array', () => {
+    const items = ['default-a', 'default-b'];
+    const target = { items, nested: { values: [[1, 2], [3]], keep: true } };
+
+    expect(deepMerge(target, { items: ['server'], nested: { values: [[]] } })).to.equal(true);
+    expect(target).to.deep.equal({ items: ['server'], nested: { values: [[]], keep: true } });
+    expect(target.items).to.equal(items);
+    deepMerge(target, { items: [], nested: { values: [] } });
+    expect(target.items).to.deep.equal([]);
+    expect(target.nested.values).to.deep.equal([]);
+  });
+
+  it('should truncate observable arrays and retain their identity', () => {
+    const target = observable({ items: ['default-a', 'default-b'], nested: [[1, 2], [3]] });
+    // Keep a reference to assert restoration preserves the live property identity.
+    // eslint-disable-next-line prefer-destructuring
+    const items = target.items;
+
+    runInAction(() => {
+      deepMerge(target, { items: ['server'], nested: [[4]] });
+    });
+    expect(target.items).to.equal(items);
+    expect([...target.items]).to.deep.equal(['server']);
+    expect(target.nested.map((row) => [...row])).to.deep.equal([[4]]);
+    runInAction(() => {
+      deepMerge(target.items, []);
+    });
+    expect(target.items.length).to.equal(0);
+  });
+
+  it('should replace properties when only one side is an array', () => {
+    const target = { array: [1, 2], object: { old: true } };
+
+    deepMerge(target, { array: { next: true }, object: [] });
+    expect(target).to.deep.equal({ array: { next: true }, object: [] });
+    expect(deepMerge(null, {})).to.equal(false);
+  });
+});

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -29,5 +29,6 @@ describe('index', () => {
     expect(api.withStores).to.equal(withStores);
     expect(api.StoreManagerProvider).to.be.a('function');
     expect(api.makeExported).to.be.a('function');
+    expect(api.makeFetching).to.equal((await import('@src/make-fetching')).default);
   });
 });

--- a/__tests__/make-fetching.ts
+++ b/__tests__/make-fetching.ts
@@ -75,6 +75,59 @@ describe('makeFetching', () => {
     expect(instance.isLoading).to.equal(false);
   });
 
+  it('should clean up a caught rejection without an unhandled rejection', async () => {
+    const error = new Error('request failed');
+    const request = Promise.reject(error);
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    const instance = {
+      isLoading: false,
+      isBusy: false,
+      request,
+      run() {
+        return this.request;
+      },
+    };
+
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      makeFetching(instance, { run: ['isLoading', 'isBusy'] });
+      const result = instance.run();
+
+      expect(result).to.equal(request);
+      expect(instance.isLoading).to.equal(true);
+      expect(instance.isBusy).to.equal(true);
+      await result.catch((reason) => expect(reason).to.equal(error));
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+      expect(instance.isLoading).to.equal(false);
+      expect(instance.isBusy).to.equal(false);
+      expect(unhandled).to.deep.equal([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('should preserve binding and reset multiple flags after a synchronous error', () => {
+    const error = new Error('sync failure');
+    const instance = {
+      isLoading: false,
+      isBusy: false,
+      error,
+      run() {
+        throw this.error;
+      },
+    };
+
+    makeFetching(instance, { run: ['isLoading', 'isBusy'] });
+
+    expect(() => instance.run()).to.throw(error);
+    expect(instance.isLoading).to.equal(false);
+    expect(instance.isBusy).to.equal(false);
+  });
+
   it('should block repeated calls when lock is enabled', () => {
     let callCount = 0;
     const instance = {
@@ -183,7 +236,7 @@ describe('makeFetching', () => {
     let callCount = 0;
     const instance = {
       isLoading: false,
-      run() {
+      run(this: void) {
         callCount += 1;
 
         return 'done';

--- a/__tests__/manager.ts
+++ b/__tests__/manager.ts
@@ -7,7 +7,7 @@ import Manager from '@src/manager';
 import onChangeListener from '@src/on-change-listener';
 import CombinedStorage from '@src/storages/combined-storage';
 import StoreStatus from '@src/store-status';
-import type { IConstructableStore } from '@src/types';
+import type { IConstructableStore, IConstructorParams } from '@src/types';
 import wakeup from '@src/wakeup';
 
 type TPersistedStoreCtor = IConstructableStore & {
@@ -310,6 +310,56 @@ describe('Manager', () => {
       logger.err,
       'Parent context has multiple stores with the same id, please pass key to getStore function.',
     );
+  });
+
+  it('should preserve store keys through ancestors and constructor helper parameters', () => {
+    class ParentStore {
+      public value = 1;
+    }
+
+    class ChildStore {
+      public parent: ParentStore | undefined;
+
+      constructor({ getStore }: IConstructorParams) {
+        this.parent = getStore(ParentStore, { key: 'second' });
+      }
+    }
+
+    const manager = new Manager();
+
+    try {
+      const { relativeStores } = manager.createStores(
+        [
+          ['first', ParentStore],
+          ['second', ParentStore],
+        ],
+        'root',
+        'parent',
+        '',
+        'Parent',
+      );
+
+      manager.createStores([], 'parent', 'middle', '', 'Middle');
+      for (const key of ['first', 'second']) {
+        expect(
+          manager.getStore(ParentStore, { contextId: 'child', parentId: 'middle', key }),
+        ).to.equal(relativeStores[key]);
+      }
+
+      expect(
+        manager.getStore(ParentStore, {
+          contextId: 'child',
+          parentId: 'middle',
+          key: 'missing',
+        }),
+      ).to.be.undefined;
+      const child = manager.createStores([['child', ChildStore]], 'middle', 'child', '', 'Child')
+        .relativeStores.child as ChildStore;
+
+      expect(child.parent).to.equal(relativeStores.second);
+    } finally {
+      manager.destroy();
+    }
   });
 
   it('should create dummy, parent and global stores through createStores', () => {

--- a/__tests__/plugins/helpers.ts
+++ b/__tests__/plugins/helpers.ts
@@ -55,6 +55,49 @@ describe('plugins/helpers', () => {
     expect(generator.getProdId()).to.equal('Sb');
   });
 
+  it('should retain cached ids and allocate unused ids across production builds', async () => {
+    let saved = '[]';
+
+    vi.doMock('node:fs', () => ({
+      default: {
+        existsSync: () => true,
+        readFileSync: () => saved,
+        writeFileSync: (_file: string, value: string) => {
+          saved = value;
+        },
+      },
+    }));
+
+    const { Generator, saveCache } = await import('@src/plugins/helpers');
+    const first = new Generator('/root', true);
+
+    first.cache.set('a.ts', { classname: 'A', storeId: first.getProdId() });
+    saveCache(first.cache);
+    const second = new Generator('/root', true);
+
+    second.cache.set('b.ts', { classname: 'B', storeId: second.getProdId() });
+    expect(second.cache.get('a.ts')?.storeId).to.equal('Sa');
+    expect(second.cache.get('b.ts')?.storeId).to.equal('Sb');
+    expect(second.getProdId()).to.equal('Sc');
+  });
+
+  it('should reject duplicate ids in a loaded production cache', async () => {
+    vi.doMock('node:fs', () => ({
+      default: {
+        existsSync: () => true,
+        readFileSync: () =>
+          JSON.stringify([
+            ['a.ts', { classname: 'A', storeId: 'Sa' }],
+            ['b.ts', { classname: 'B', storeId: 'Sa' }],
+          ]),
+      },
+    }));
+
+    const { Generator } = await import('@src/plugins/helpers');
+
+    expect(() => new Generator('/root', true)).to.throw('Duplicate store ID "Sa"');
+  });
+
   it('should detect stores, inject ids and ignore unmatched classes', async () => {
     const { Generator } = await import('@src/plugins/helpers');
     const generator = new Generator('/root');

--- a/__tests__/plugins/vite/id-generator.ts
+++ b/__tests__/plugins/vite/id-generator.ts
@@ -21,6 +21,17 @@ describe('plugins/vite/id-generator', () => {
       .undefined;
   });
 
+  it('should inject an id for a tagged store without observable helper calls', async () => {
+    const { default: IdGenerator } = await import('@src/plugins/vite/id-generator');
+    const plugin = IdGenerator({ root: '/root' });
+    const code = '/** @mobx-store */ class Tagged { value = 1; }';
+    const result = callTransform(plugin.transform, code, '/root/tagged.ts') as { code: string };
+
+    expect(result.code).to.include("static id = 'tagged.ts-Tagged';");
+    expect(callTransform(plugin.transform, 'class Plain { value = 1; }', '/root/plain.ts')).to.be
+      .undefined;
+  });
+
   it('should inject id from cache or generated class match', async () => {
     const cachedFileId = '/cached.ts';
     const transformedCode = 'cached-code';

--- a/__tests__/storages/async-storage.ts
+++ b/__tests__/storages/async-storage.ts
@@ -37,6 +37,24 @@ describe('AsyncStorage', () => {
     sinon.assert.calledOnce(error);
   });
 
+  it('should round trip undefined as an empty object', async () => {
+    let raw: string | undefined;
+    const storage = {
+      getItem: sandbox.stub().callsFake(() => Promise.resolve(raw ?? null)),
+      setItem: sandbox.stub().callsFake((_key: string, value: string) => {
+        raw = value;
+
+        return Promise.resolve();
+      }),
+      removeItem: sandbox.stub(),
+    };
+    const target = new AsyncStorage({ storage });
+
+    await Promise.resolve(target.set(undefined));
+    expect(raw).to.equal('{}');
+    expect(await Promise.resolve(target.get())).to.deep.equal({});
+  });
+
   it('should delegate set and flush and handle storage failures', async () => {
     const storage = {
       getItem: sandbox.stub().resolves('{}'),

--- a/__tests__/storages/combined-storage.ts
+++ b/__tests__/storages/combined-storage.ts
@@ -129,6 +129,35 @@ describe('CombinedStorage', () => {
     sinon.assert.calledOnceWithExactly(setSecondary, { store: { bar: 2 } });
   });
 
+  it.each(['A', 'B'])(
+    'should save %s after flush without skipping or resurrecting data',
+    async (id) => {
+      let durable: Record<string, unknown> = {};
+      const set = sandbox.spy((value: Record<string, unknown> | undefined) => {
+        durable = value ?? {};
+      });
+      const target = new CombinedStorage({
+        primary: {
+          get: () => durable,
+          set,
+          flush: async () => {
+            await Promise.resolve();
+            durable = {};
+          },
+        },
+      });
+
+      await target.get();
+      await target.saveStoreData({ libStoreId: 'A' }, { count: 1 });
+      await target.flush();
+      expect(durable).to.deep.equal({});
+      expect(target.getStoreData({ libStoreId: 'A' })).to.deep.equal({});
+      await target.saveStoreData({ libStoreId: id }, { count: 1 });
+      expect(durable).to.deep.equal({ [id]: { count: 1 } });
+      sinon.assert.calledTwice(set);
+    },
+  );
+
   it('should support include behaviour and flush all storages', async () => {
     const flushPrimary = sandbox.stub().resolves();
     const flushSecondary = sandbox.stub().resolves();

--- a/__tests__/storages/cookie-storage.ts
+++ b/__tests__/storages/cookie-storage.ts
@@ -35,6 +35,22 @@ describe('CookieStorage', () => {
     expect(result).to.deep.equal({});
   });
 
+  it('should round trip undefined as an empty object', async () => {
+    let raw: string | undefined;
+    const storage = {
+      get: sandbox.stub().callsFake(() => raw),
+      set: sandbox.stub().callsFake((_key: string, value: string) => {
+        raw = value;
+      }),
+      remove: sandbox.stub(),
+    };
+    const target = new CookieStorage({ storage });
+
+    await Promise.resolve(target.set(undefined));
+    expect(raw).to.equal('{}');
+    expect(await Promise.resolve(target.get())).to.deep.equal({});
+  });
+
   it('should delegate set and flush with cookie attributes', () => {
     const storage = {
       get: sandbox.stub(),

--- a/__tests__/storages/local-storage.ts
+++ b/__tests__/storages/local-storage.ts
@@ -38,6 +38,22 @@ describe('LocalStorage', () => {
     expect(result).to.deep.equal({});
   });
 
+  it('should round trip undefined as an empty object', async () => {
+    let raw: string | undefined;
+    const storage = {
+      getItem: sandbox.stub().callsFake(() => raw),
+      setItem: sandbox.stub().callsFake((_key: string, value: string) => {
+        raw = value;
+      }),
+      removeItem: sandbox.stub(),
+    };
+    const target = new LocalStorage({ storage: storage as unknown as Storage });
+
+    await Promise.resolve(target.set(undefined));
+    expect(raw).to.equal('{}');
+    expect(await Promise.resolve(target.get())).to.deep.equal({});
+  });
+
   it('should delegate set and flush to underlying storage', () => {
     const storage = {
       getItem: sandbox.stub(),

--- a/__tests__/suspense-query.ts
+++ b/__tests__/suspense-query.ts
@@ -47,6 +47,49 @@ describe('SuspenseQuery', () => {
     expect(target.query(() => Promise.resolve('unused'), { hash: 'hash-1' })).to.be.undefined;
   });
 
+  it.each(['resolve', 'reject'] as const)(
+    'should ignore an obsolete query that settles with %s',
+    async (settlement) => {
+      let resolveOld!: () => void;
+      let rejectOld!: (reason: Error) => void;
+      let resolveNew!: () => void;
+      const old = new Promise<void>((resolve, reject) => {
+        resolveOld = resolve;
+        rejectOld = reject;
+      });
+      const current = new Promise<void>((resolve) => {
+        resolveNew = resolve;
+      });
+      const store: Record<string, unknown> = {};
+      const query = new SuspenseQuery(store);
+
+      for (const [hash, promise] of [
+        ['A', old],
+        ['B', current],
+      ] as const) {
+        try {
+          query.query(() => promise, { hash });
+        } catch (pending) {
+          expect(pending).to.equal(promise);
+        }
+      }
+
+      resolveNew();
+      await current;
+      expect(store.sR).to.deep.equal({ hash: 'B', done: true });
+
+      if (settlement === 'resolve') {
+        resolveOld();
+      } else {
+        rejectOld(new Error('obsolete A failed'));
+      }
+
+      await old.catch(() => undefined);
+      expect(store.sR).to.deep.equal({ hash: 'B', done: true });
+      expect(query.query(() => Promise.resolve(), { hash: 'B' })).to.be.undefined;
+    },
+  );
+
   it('should serialize error and rethrow it from init wrapper', async () => {
     const store: Record<string, any> = {
       init: () => 'init-called',

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -644,7 +644,7 @@ Behavior:
 - `connectReactNativeHmr(manager, runtime?, options?)`
 - `connectViteHmr(manager, runtime?, options?)`
 - `connectWebpackHmr(manager, runtime?, options?)`
-- default export `connectHmrRuntime(manager, runtime?, options?)`
+- named export `connectHmrRuntime(manager, runtime?, options?)`
 - `ManagerHmr`
 
 `ManagerHmr` methods:

--- a/docs/api/helpers.md
+++ b/docs/api/helpers.md
@@ -21,7 +21,7 @@ Returned runtime value:
 }
 ```
 
-## `Manager.persistStore(Store, id?, options?)`
+## `Manager.persistStore(Store, id, options?)`
 
 Marks store as persisted and wires default persistence hooks.
 

--- a/docs/guide/hmr.md
+++ b/docs/guide/hmr.md
@@ -67,3 +67,5 @@ if (__DEV__) {
 - Relative stores usually restore correctly while their ids stay stable.
 - Global stores restore especially well because their ids are naturally stable.
 - HMR support is not a guarantee of instance identity reuse. It restores state, not old object instances.
+
+The HMR entry exports `connectHmrRuntime` by name (`import { connectHmrRuntime } from '@lomray/react-mobx-manager/plugins/dev-extension/hmr'`); it has no default export.

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@lomray/consistent-suspense": ">=2.0.1",
         "@lomray/event-manager": ">=2.0.2",
         "hoist-non-react-statics": ">=3.3.2",
-        "lodash": ">=4.17.21",
+        "lodash": ">=4.18.1",
         "mobx": ">=6.9.0",
         "mobx-react-lite": "^3 || ^4 || ^5",
         "react": "^19 || ^18 || ^17"
@@ -9586,9 +9586,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@lomray/consistent-suspense": ">=2.0.1",
     "@lomray/event-manager": ">=2.0.2",
     "hoist-non-react-statics": ">=3.3.2",
-    "lodash": ">=4.17.21",
+    "lodash": ">=4.18.1",
     "mobx": ">=6.9.0",
     "mobx-react-lite": "^3 || ^4 || ^5",
     "react": "^19 || ^18 || ^17"
@@ -87,5 +87,33 @@
       "browserslist-generator": "^3.0.0"
     }
   },
-  "packageManager": "npm@11.5.2"
+  "packageManager": "npm@11.5.2",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./plugins/vite": {
+      "types": "./plugins/vite/index.d.ts",
+      "default": "./plugins/vite/index.js"
+    },
+    "./plugins/dev-extension": {
+      "types": "./plugins/dev-extension/index.d.ts",
+      "default": "./plugins/dev-extension/index.js"
+    },
+    "./plugins/dev-extension/hmr": {
+      "types": "./plugins/dev-extension/hmr/index.d.ts",
+      "default": "./plugins/dev-extension/hmr/index.js"
+    },
+    "./package.json": "./package.json",
+    "./*.js": {
+      "types": "./*.d.ts",
+      "default": "./*.js"
+    },
+    "./*": {
+      "types": "./*.d.ts",
+      "default": "./*.js"
+    }
+  }
 }

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -69,7 +69,7 @@ const StoreManagerProvider: FC<IStoreManagerProvider> = ({
   return (
     <StoreManagerContext.Provider value={storeManager}>
       <StoreManagerParentProvider parentId="root">
-        {isInit ? children : fallback || children}
+        {isInit ? children : (fallback ?? null)}
       </StoreManagerParentProvider>
     </StoreManagerContext.Provider>
   );

--- a/src/deep-merge.ts
+++ b/src/deep-merge.ts
@@ -11,9 +11,19 @@ const deepMerge = (target: any, source: any): boolean => {
     return false;
   }
 
+  if (Array.isArray(target) && Array.isArray(source)) {
+    target.splice(0, target.length, ...(source as unknown[]));
+
+    return true;
+  }
+
   for (const key in source) {
     if (target.hasOwnProperty(key)) {
-      if (isObject(target[key]) && isObject(source[key])) {
+      if (
+        isObject(target[key]) &&
+        isObject(source[key]) &&
+        Array.isArray(target[key]) === Array.isArray(source[key])
+      ) {
         deepMerge(target[key] as Record<string, any>, source[key] as Record<string, any>);
       } else {
         target[key] = source[key];

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export { default as parentStore } from './parent-store';
 
 export * from './make-exported';
 
-export * from './make-fetching';
+export { default as makeFetching } from './make-fetching';
 
 export { default as Events } from './events';
 

--- a/src/make-fetching.ts
+++ b/src/make-fetching.ts
@@ -87,9 +87,7 @@ function makeFetching<T extends Record<any, any>>(
         typeof result === 'object' &&
         typeof (result as { finally?: unknown }).finally === 'function'
       ) {
-        void (result as Promise<unknown>).finally(() => {
-          decrement();
-        });
+        void (result as Promise<unknown>).then(decrement, decrement);
       } else {
         decrement();
       }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -243,14 +243,16 @@ class Manager {
    * Lookup store
    */
   protected lookupStore(id: string, params: IStoreParams): TInitStore<TAnyStore> | undefined {
-    const { contextId, parentId: defaultParentId } = params;
+    const { contextId, parentId: defaultParentId, key } = params;
     const clearId = id.split('--')?.[0];
     const { ids, parentId } = this.storesRelations.get(contextId!) ?? {
       ids: new Set(),
       parentId: defaultParentId,
     };
 
-    const matchedIds = [...ids].filter((storeId) => storeId.startsWith(`${clearId}--`));
+    const matchedIds = [...ids].filter(
+      (storeId) => storeId.startsWith(`${clearId}--`) && (!key || storeId.endsWith(`--${key}`)),
+    );
 
     if (matchedIds.length === 1) {
       return this.stores.get(matchedIds[0]);
@@ -266,7 +268,10 @@ class Manager {
       return undefined;
     }
 
-    return this.lookupStore(id, { contextId: this.getBiggerContext(parentId, defaultParentId) });
+    return this.lookupStore(id, {
+      contextId: this.getBiggerContext(parentId, defaultParentId),
+      key,
+    });
   }
 
   /**
@@ -301,10 +306,8 @@ class Manager {
     const newStore = new store({
       ...this.storesParams,
       storeManager: this,
-      getStore: <TS>(
-        targetStore: IConstructableStore<TS>,
-        targetParams = { contextId, parentId },
-      ) => this.getStore(targetStore, targetParams),
+      getStore: <TS>(targetStore: IConstructableStore<TS>, targetParams = {}) =>
+        this.getStore(targetStore, { contextId, parentId, ...targetParams }),
       componentProps,
       initState: this.initState[id],
     });

--- a/src/plugins/helpers.ts
+++ b/src/plugins/helpers.ts
@@ -19,7 +19,20 @@ const loadCache = (isProd = false): ICache => {
   if (isProd && fs.existsSync(cacheFile)) {
     const cache = JSON.parse(fs.readFileSync(cacheFile, { encoding: 'utf-8' }));
 
-    return new Map(cache as any[]);
+    const result: ICache = new Map(cache as any[]);
+    const used = new Set<string>();
+
+    for (const { storeId } of result.values()) {
+      if (used.has(storeId)) {
+        throw new Error(
+          `Duplicate store ID "${storeId}" in ${cacheFile}. Remove the cache and rebuild.`,
+        );
+      }
+
+      used.add(storeId);
+    }
+
+    return result;
   }
 
   return new Map();
@@ -99,10 +112,13 @@ class Generator {
    * Get production store id
    */
   public getProdId = (): string => {
-    const nextLetter = getNextLetter(this.lastId);
-    const id = `S${nextLetter}`;
+    const used = new Set([...this.cache.values()].map(({ storeId }) => storeId));
+    let id: string;
 
-    this.lastId = nextLetter;
+    do {
+      this.lastId = getNextLetter(this.lastId);
+      id = `S${this.lastId}`;
+    } while (used.has(id));
 
     return id;
   };

--- a/src/plugins/vite/id-generator.ts
+++ b/src/plugins/vite/id-generator.ts
@@ -27,7 +27,7 @@ function IdGenerator({ root = cwd(), isProd = false }: IPluginOptions = {}): Plu
       if (
         id.includes('node_modules') ||
         !['.js', '.ts', '.tsx'].includes(extName) ||
-        !/(makeObservable|makeAutoObservable)\(/.test(code)
+        (!/(makeObservable|makeAutoObservable)\(/.test(code) && !code.includes('@mobx-store'))
       ) {
         return;
       }

--- a/src/storages/async-storage.ts
+++ b/src/storages/async-storage.ts
@@ -65,7 +65,7 @@ class AsyncStorage implements IStorage {
    */
   async set(value: Record<string, any> | undefined): Promise<void> {
     try {
-      return await this.storage.setItem(this.globalKey, JSON.stringify(value || '{}'));
+      return await this.storage.setItem(this.globalKey, JSON.stringify(value ?? {}));
     } catch (e) {
       console.error('Failed to set value to async storage:', e);
     }

--- a/src/storages/combined-storage.ts
+++ b/src/storages/combined-storage.ts
@@ -62,8 +62,11 @@ class CombinedStorage implements IStorage {
   /**
    * @inheritDoc
    */
-  public flush(): Promise<any> {
-    return Promise.all(Object.values(this.storages).map((storage) => storage.flush() as any));
+  public async flush(): Promise<void> {
+    await Promise.all(
+      Object.values(this.storages).map((storage) => Promise.resolve(storage.flush())),
+    );
+    this.persistData = {};
   }
 
   /**

--- a/src/storages/cookie-storage.ts
+++ b/src/storages/cookie-storage.ts
@@ -71,7 +71,7 @@ class CookieStorage implements IStorage {
    * @inheritDoc
    */
   public set(value: Record<string, any> | undefined): void {
-    return this.storage.set(this.globalKey, JSON.stringify(value || '{}'), this.cookieAttr);
+    return this.storage.set(this.globalKey, JSON.stringify(value ?? {}), this.cookieAttr);
   }
 }
 

--- a/src/storages/local-storage.ts
+++ b/src/storages/local-storage.ts
@@ -49,7 +49,7 @@ class LocalStorage implements IStorage {
    * @inheritDoc
    */
   set(value: Record<string, any> | undefined): void {
-    return this.storage.setItem(this.globalKey, JSON.stringify(value || '{}'));
+    return this.storage.setItem(this.globalKey, JSON.stringify(value ?? {}));
   }
 }
 

--- a/src/suspense-query.ts
+++ b/src/suspense-query.ts
@@ -144,13 +144,22 @@ class SuspenseQuery {
     }
 
     if (!this.promise) {
-      this.promise = promise();
+      const pending = promise();
 
-      this.promise.then(
+      this.promise = pending;
+      pending.then(
         () => {
+          if (this.promise !== pending) {
+            return;
+          }
+
           this.store[fieldName] = { hash, done: true };
         },
         (e) => {
+          if (this.promise !== pending) {
+            return;
+          }
+
           this.errorJson(e);
 
           this.store[fieldName] = { error: e };


### PR DESCRIPTION
## Goal

Fix the defects found while auditing `@lomray/react-mobx-manager` 4.5.0 on the current template stack (React 19, MobX 7, streaming SSR through vite-ssr-boost 8).

## Changes (one commit per finding)

- `makeFetching`: cleanup is attached with `then(decrement, decrement)`; a rejected request that the caller catches no longer produces an unhandled rejection (which terminated Node processes).
- Production store ids: a new generator allocates ids that are not already in the loaded cache; adding a store between builds no longer reuses an existing id (two stores answered to `Sa`).
- `deepMerge`: arrays are replaced, including truncation, instead of being merged index by index; restoring `items: ["server"]` over `["default-a", "default-b"]` no longer yields `["server", "default-b"]` and a hydration mismatch.
- Suspense queries ignore results of an obsolete promise after the hash changed.
- The provider renders only the fallback (or nothing) before initialization instead of children with an empty cache; documented for `shouldInit` users.
- `flush()` resets the persistence cache, so a later save is not skipped and flushed data is not resurrected.
- Parent-store lookup keeps the requested `key` at every level; the constructor helper forwards it.
- Storages persist `{}` for `undefined` instead of the string `"{}"`.
- The Vite plugin injects ids for stores tagged `@mobx-store` without a `makeObservable` call.
- `exports` map (extensionless and `.js` subpaths, `./package.json`), `makeFetching` exported from the root, lodash raised to a patched version; persistence-id and HMR docs corrected.

## Verification

Node 22.23.2, local:

- `npm run lint:check`, `npm run ts:check`, `npm test`: 107 tests on MobX 7.0.3 + mobx-react-lite 5.0.3 and on MobX 6.16.1 + mobx-react-lite 4.1.1.
- `npm run build`; packed build installed into a temporary consumer: root `makeFetching`, `manager-stream` and `plugins/vite` subpaths resolve under `bundler` and `node16` and in native Node ESM; the audit's rejection probe survives.
- Copy of vite-template `prod` with the packed build: `ts:check`, build and `npm run smoke` pass; `/details` and `/nested-suspense` stream one `window.mbxM.push` state script per `data-suspense-id` marker.

## Not run

- Hosted CI runs on this PR.
